### PR TITLE
set float button invisible in mobile mode, for faq pages only

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -876,6 +876,20 @@ p9 {
   margin: 1em;
   right: 25px;
 }
+
+.sbutton-faq{
+  display: inline-block;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  text-align: center;
+  color:#FFF;
+  font-size: 35px;
+  margin: 20px auto 0;
+  box-shadow: 0px 5px 11px -2px rgba(0, 0, 0, 0.18), 0px 4px 12px -7px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+}
+
 .sbutton {
   display: block;
   width: 60px;
@@ -890,13 +904,18 @@ p9 {
 }
 .sbutton:active,
 .sbutton:focus,
-.sbutton:hover {
+.sbutton:hover,
+.sbutton-faq:active,
+.sbutton-faq:focus,
+.sbutton-faq:hover {
   box-shadow: 0 0 4px rgba(0, 0, 0, .14), 0 4px 8px rgba(0, 0, 0, .28);
 }
-.sbutton.instagram {
+.sbutton.instagram,
+.sbutton-faq.instagram {
   background-color: #8a3ab9;
 }
-.sbutton.whatsapp {
+.sbutton.whatsapp,
+.sbutton-faq.whatsapp {
   background-color: #00e676;
 }
 @media screen and (min-width: 1280px) {

--- a/faq.html
+++ b/faq.html
@@ -453,12 +453,19 @@
         <!-- / v-pills-widsom-tooth-surgery-tab -->
       </div>
     </div>
+    <div class="mx-auto d-block d-sm-none">
+      <a href="https://instagram.com/wongandsimdental" target="_blank" class="sbutton-faq instagram"><i class="fa fa-instagram my-float"></i></a>
+      <a href="https://wa.me/60129690106" target="_blank" class="sbutton-faq whatsapp"><i class="fa fa-whatsapp my-float"></i></a>
+    </div>
   </div>
 </div>
-<div class="sbuttons">
-  <a href="https://instagram.com/wongandsimdental" target="_blank" class="sbutton instagram"><i class="fa fa-instagram my-float"></i></a>
-  <a href="https://wa.me/60129690106" target="_blank" class="sbutton whatsapp"><i class="fa fa-whatsapp my-float"></i></a>
+<div class="d-none d-sm-block">
+  <div class="sbuttons">
+    <a href="https://instagram.com/wongandsimdental" target="_blank" class="sbutton instagram"><i class="fa fa-instagram my-float"></i></a>
+    <a href="https://wa.me/60129690106" target="_blank" class="sbutton whatsapp"><i class="fa fa-whatsapp my-float"></i></a>
+  </div>
 </div>
+
 <!-- Footer -->
 <footer class="page-footer mt-3">
   <!-- Copyright -->


### PR DESCRIPTION
## Before: (Mobile Mode)
The submenu blocking faq page content
<img width="453" alt="Screenshot 2022-04-04 at 2 37 09 PM" src="https://user-images.githubusercontent.com/7873044/161487398-81b04854-d2d4-4022-896a-b2547d8f39da.png">

## After (Mobile Mode)
Set submenu to last page (FAQS pages only)
<img width="383" alt="Screenshot 2022-04-04 at 2 36 12 PM" src="https://user-images.githubusercontent.com/7873044/161487477-504f3924-0126-45d3-8fd7-894b62888d61.png">
Browser mode
<img width="1440" alt="Screenshot 2022-04-04 at 2 36 30 PM" src="https://user-images.githubusercontent.com/7873044/161487754-db602f35-0786-4724-a55c-2639495145f4.png">


